### PR TITLE
fix(no update): added check for no updates

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -78,7 +78,11 @@ createConnection({
               petition.debate = true;
             }
 
-            return tweets;
+            if (tweets) {
+              return tweets;
+            }
+
+            return Promise.reject(`this petition has no updates`);
           })
           .then((tweets) => updateTweet(petition.tweetId, tweets))
           .then((tweetId) => {
@@ -96,8 +100,9 @@ createConnection({
             updatesMade++;
           })
           .catch((error) => {
-            console.error(error);
-            console.error("it's peak");
+            console.error(
+              `Update failed for Petition (${petition.id}) because ${error}`
+            );
           });
         if (updatesMade >= UPDATE_LIMIT) {
           console.log("Process finished successfully");


### PR DESCRIPTION
Petitions with no updates still counted as successful updates. This led to a block where the script would "update" the same few petition tweets whenever run.